### PR TITLE
feat: Editor, Viewer 관련 테스트 코드 추가

### DIFF
--- a/src/domains/shared/components/editor/EditorWithForwarded.tsx
+++ b/src/domains/shared/components/editor/EditorWithForwarded.tsx
@@ -1,0 +1,30 @@
+import Prism from 'prismjs';
+// 여기 css를 수정해서 코드 하이라이팅 커스텀 가능
+import 'prismjs/themes/prism.css';
+import 'prismjs/components/prism-typescript.min';
+import 'prismjs/components/prism-jsx.min';
+import 'prismjs/components/prism-tsx.min';
+import '@toast-ui/editor-plugin-code-syntax-highlight/dist/toastui-editor-plugin-code-syntax-highlight.css';
+import 'tui-color-picker/dist/tui-color-picker.css';
+import '@toast-ui/editor-plugin-color-syntax/dist/toastui-editor-plugin-color-syntax.css';
+import '@toast-ui/editor/dist/toastui-editor.css';
+import { Editor, EditorProps } from '@toast-ui/react-editor';
+import codeSyntaxHighlight from '@toast-ui/editor-plugin-code-syntax-highlight';
+import colorSyntax from '@toast-ui/editor-plugin-color-syntax';
+import { ForwardedRef } from 'react';
+
+export interface EditorWithForwardedProps extends EditorProps {
+  forwardedRef?: ForwardedRef<Editor | null>;
+}
+
+const EditorWithForwarded = (props: EditorWithForwardedProps) => {
+  return (
+    <Editor
+      {...props}
+      plugins={[[codeSyntaxHighlight, { highlighter: Prism }], colorSyntax]}
+      ref={props.forwardedRef}
+    />
+  );
+};
+
+export default EditorWithForwarded;

--- a/src/domains/shared/components/editor/Viewer.tsx
+++ b/src/domains/shared/components/editor/Viewer.tsx
@@ -1,27 +1,39 @@
 import Prism from 'prismjs';
 // 여기 css를 수정해서 코드 하이라이팅 커스텀 가능
 import 'prismjs/themes/prism.css';
-
 import '@toast-ui/editor/dist/toastui-editor.css';
-
 import '@toast-ui/editor-plugin-code-syntax-highlight/dist/toastui-editor-plugin-code-syntax-highlight.css';
 import { ReactElement, useCallback, useEffect, useState } from 'react';
 
-export default function PostView() {
-  const [postViewer, setPostViewer] = useState<ReactElement | null>(null);
+interface PostViewProps {
+  initialValue: string;
+  onLoadEnd?: () => void;
+}
+
+// Next의 dynamic으로 import 시 codeSyntaxHighlight 설정이 어렵다.
+// Editor와 통일적이진 않지만, 해결 방법이 없어 useEffect 안에서 dynamic import 하는걸로 대체한다.
+
+export default function PostView({ initialValue, onLoadEnd }: PostViewProps) {
+  const [PostViewer, setPostViewer] = useState<ReactElement | null>(null);
 
   const getViewerDynamic = useCallback(async () => {
     const { Viewer } = await import('@toast-ui/react-editor');
     const codeSyntaxHighlight = await import('@toast-ui/editor-plugin-code-syntax-highlight');
 
     setPostViewer(
-      <Viewer initialValue="## testetstst" plugins={[[codeSyntaxHighlight.default, { highlighter: Prism }]]} />,
+      <Viewer initialValue={initialValue} plugins={[[codeSyntaxHighlight.default, { highlighter: Prism }]]} />,
     );
+
+    onLoadEnd?.();
   }, []);
 
   useEffect(() => {
-    getViewerDynamic();
-  }, []);
+    if (!initialValue) {
+      return;
+    }
 
-  return postViewer;
+    getViewerDynamic();
+  }, [initialValue]);
+
+  return PostViewer;
 }

--- a/src/domains/shared/components/editor/Writer.tsx
+++ b/src/domains/shared/components/editor/Writer.tsx
@@ -1,46 +1,12 @@
-import Prism from 'prismjs';
-// 여기 css를 수정해서 코드 하이라이팅 커스텀 가능
-import 'prismjs/themes/prism.css';
-import 'prismjs/components/prism-typescript.min';
-import 'prismjs/components/prism-jsx.min';
-import 'prismjs/components/prism-tsx.min';
-import '@toast-ui/editor/dist/toastui-editor.css';
+import React, { Component, forwardRef, ReactElement, useCallback, useEffect, useState } from 'react';
+import dynamic from 'next/dynamic';
+import { Editor as EditorType } from '@toast-ui/react-editor';
+import { EditorWithForwardedProps } from './EditorWithForwarded';
 
-import '@toast-ui/editor-plugin-code-syntax-highlight/dist/toastui-editor-plugin-code-syntax-highlight.css';
-// import codeSyntaxHighlight from '@toast-ui/editor-plugin-code-syntax-highlight';
+const Editor = dynamic<EditorWithForwardedProps>(() => import('./EditorWithForwarded'), { ssr: false });
 
-import 'tui-color-picker/dist/tui-color-picker.css';
-import '@toast-ui/editor-plugin-color-syntax/dist/toastui-editor-plugin-color-syntax.css';
-// import colorSyntax from '@toast-ui/editor-plugin-color-syntax';
-import { ReactElement, useCallback, useEffect, useState } from 'react';
+const Writer = forwardRef<EditorType, {}>((props, ref) => {
+  return <Editor forwardedRef={ref} />;
+});
 
-export default function Writer() {
-  const [postEditor, setPostEditor] = useState<ReactElement | null>(null);
-
-  const getEditorDynamic = useCallback(async () => {
-    const { Editor } = await import('@toast-ui/react-editor');
-    const codeSyntaxHighlight = await import('@toast-ui/editor-plugin-code-syntax-highlight');
-    const colorSyntax = await import('@toast-ui/editor-plugin-color-syntax');
-
-    setPostEditor(
-      <Editor
-        previewStyle="vertical"
-        plugins={[[codeSyntaxHighlight.default, { highlighter: Prism }], colorSyntax.default]}
-      />,
-    );
-  }, []);
-
-  useEffect(() => {
-    getEditorDynamic();
-
-    // import('@toast-ui/react-editor').then(({ Editor }) =>
-    //   setPostEditor(
-    //     <Editor
-    //       plugins={[[codeSyntaxHighlight, { highlighter: Prism }], colorSyntax]}
-    //     />
-    //   )
-    // );
-  }, []);
-
-  return postEditor;
-}
+export default Writer;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,12 +1,39 @@
 import type { NextPage } from 'next';
+import dynamic from 'next/dynamic';
 import Head from 'next/head';
 import Writer from '../domains/shared/components/editor/Writer';
-import Viewer from '../domains/shared/components/editor/Viewer';
 import Button from '../domains/shared/components/Button';
 import { useCounterStore } from '../domains/shared/store/counter';
+import { useEffect, useRef, useState } from 'react';
+import { Editor } from '@toast-ui/react-editor';
+
+const Viewer = dynamic(() => import('../domains/shared/components/editor/Viewer'), { ssr: false });
 
 const Home: NextPage = () => {
   const { count, increase, decrease, increaseByValue } = useCounterStore();
+  const writerRef = useRef<Editor>(null);
+  const [content, setContent] = useState('');
+
+  const onSaveContent = () => {
+    const writerInstance = writerRef.current?.getInstance();
+    const writerContent = writerInstance?.isMarkdownMode ? writerInstance?.getMarkdown() : writerInstance?.getHTML();
+
+    if (writerContent) {
+      setContent(writerContent);
+    }
+  };
+
+  useEffect(() => {
+    if (writerRef.current) {
+      writerRef.current.getInstance().removeHook('addImageBlobHook');
+
+      writerRef.current.getInstance().addHook('addImageBlobHook', (blob, callback) => {
+        console.log(blob); // 이미지 업로드를 하고, 그 주소를 editor에 보여주게 하기
+        // https://velog.io/@developerjhp/Toast-UI-Editor%EC%97%90%EC%84%9C-s3%EB%A1%9C-%EC%9D%B4%EB%AF%B8%EC%A7%80-%EC%97%85%EB%A1%9C%EB%93%9C-%ED%95%98%EB%8A%94-%EB%B0%A9%EB%B2%95
+        // https://myeongjae.kim/blog/2020/04/05/tui-editor-with-nextjs
+      });
+    }
+  }, []);
 
   return (
     <div>
@@ -17,20 +44,19 @@ const Home: NextPage = () => {
       </Head>
 
       <main>
-        <Writer />
-        <Viewer />
+        <Writer ref={writerRef} />
+        {content && <Viewer initialValue={content} />}
 
+        <Button onClick={onSaveContent}>확인해보기</Button>
         <div>본 카운트: {count}</div>
         <TestComponent />
 
         <Button color="primary" size="large" onClick={increase}>
           증가하기
         </Button>
-        <Viewer />
         <Button color="secondary" size="medium" onClick={decrease}>
           감소하기
         </Button>
-        <Viewer />
         <Button color="default" size="small" onClick={() => increaseByValue(5)}>
           많이 증가하기
         </Button>


### PR DESCRIPTION
일단 간단하게 추가 해봤어요.
Editor에 글을 쓰고, 확인하기를 누르면 Viewer에서 잘 보이는지 테스트 해봤습니다.

확인하기를 누르면 -> 서버로 보내고, 업로드 다하고 나면 detail로 이동 시켜서 Viewer를 통해 보이게 하는 식으로 구현하면 될거 같아요.
이미지 업로드는 기존 코드대로 하면 base64 형식으로 말도 안 되게 길게 나오더라구여~ 그래서 일단은 제외시켜놓고, 현재 코드에서 서버로 이미지 저장할 수 있게 요청한 뒤 반환 되는 url 값 사용하게 하면 될 것 같습니다.

Toast UI 가 SSR은 지원하지 않아서 내용 부분에 SSR 사용은 못 할거 같고, SSR에서 가지고 온 정보는 Head 에 적절한 meta 태그에 넣어서 
SEO 잘 되게 만드는 용도로 사용하고, CSR에서 해당 내용이 보이게 해야할 것 같습니다.

![스크린샷 2022-05-12 오전 1 04 59](https://user-images.githubusercontent.com/38036598/167898329-f7be20cd-523a-4c80-86d3-a352e2d2af24.png)
 